### PR TITLE
Add Arabic option for coin-data page

### DIFF
--- a/mysite/coins/templates/coins/coin_data.html
+++ b/mysite/coins/templates/coins/coin_data.html
@@ -1,5 +1,9 @@
 <!DOCTYPE html>
+{% if in_arabic %}
+<html lang="ar" dir="rtl">
+{% else %}
 <html lang="en">
+{% endif %}
 <head>
     <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
@@ -33,6 +37,12 @@
         <hr>
         <div class="d-flex justify-content-center">
             <span class="fs-4">Coin View</span>
+            <span class="fs-4">&nbsp;</span>
+            {% if in_arabic %}
+            <a href="?id={{ data.11 }}" class="fs-4">[English]</a>
+            {% else %}
+            <a href="?id={{ data.11 }}&in_arabic=true" class="fs-4">[اللغة العربية]</a>
+            {% endif %}
         </div>
         <hr>
 
@@ -41,16 +51,16 @@
                 <p class="fs-3 px-3 fw-bold">{{data.0}}</p>
                 <hr>
                 <div class="d-flex flex-column align-items-start align-items-sm-start px-3 pt-2"></divclass>
-                    <p class="fs-5">Description: {{ data.3 }}</p>
-                    <p class="fs-5">Origin: {{ data.4 }}</p>
-                    <p class="fs-5">Time Period: {{ data.5 }}</p>
-                    <p class="fs-5">Date: {{ data.1 }}</p>
-                    <p class="fs-5">Material: {{ data.6 }}</p>
-                    <p class="fs-5">Die Axis: {{ data.7 }} degrees</p>
-                    <p class="fs-5">Diameter: {{ data.8 }} mm</p>
-                    <p class="fs-5">Mass: {{ data.9 }} grams</p>
-                    <p class="fs-5">Accession Number: {{ data.10 }}</p>
-                    <p class="fs-5">WikiData ID: {{ data.11 }}</p>
+                    <p class="fs-5">{{ labels.0 }}: {{ data.3 }}</p>
+                    <p class="fs-5">{{ labels.1 }}: {{ data.4 }}</p>
+                    <p class="fs-5">{{ labels.2 }}: {{ data.5 }}</p>
+                    <p class="fs-5">{{ labels.3 }}: {{ data.1 }}</p>
+                    <p class="fs-5">{{ labels.4 }}: {{ data.6 }}</p>
+                    <p class="fs-5">{{ labels.5 }}: {{ data.7 }} °</p>
+                    <p class="fs-5">{{ labels.6 }}: {{ data.8 }} mm</p>
+                    <p class="fs-5">{{ labels.7 }}: {{ data.9 }} g</p>
+                    <p class="fs-5">{{ labels.8 }}: {{ data.10 }}</p>
+                    <p class="fs-5">{{ labels.9 }}: {{ data.11 }}</p>
                 </div>
                 
             </div>

--- a/mysite/coins/utils.py
+++ b/mysite/coins/utils.py
@@ -107,7 +107,7 @@ def convert_to_date(date):
     
     return date
 
-def get_coin(qid):
+def get_coin(qid, in_arabic = False):
     ssl._create_default_https_context = ssl._create_unverified_context
     sparql = SPARQLWrapper("https://query.wikidata.org/sparql")
     sparql.setReturnFormat(JSON)
@@ -123,6 +123,8 @@ def get_coin(qid):
                         ?statement pq:P1319 ?earliestdate.
                         ?statement pq:P1326 ?latestdate.}"""
 
+    language_params = f'"{("ar," if in_arabic else "")}[AUTO_LANGUAGE],en"'
+    
     sparql.setQuery(""" 
           SELECT ?item ?itemDescription ?itemLabel ?invNum ?image ?period ?materialLabel ?axis ?diameter ?mass ?originLabel ?earliestdate ?latestdate ?date
             WHERE 
@@ -144,7 +146,7 @@ def get_coin(qid):
                         ?ms ps:P2067 ?mass.}
                 OPTIONAL { ?item p:P1071 ?or.
                         ?or ps:P1071 ?origin.} """ + dateSPARQL + """
-                SERVICE wikibase:label { bd:serviceParam wikibase:language "[AUTO_LANGUAGE],en".}
+                SERVICE wikibase:label { bd:serviceParam wikibase:language """+ language_params +""".}
             }
     """
     )

--- a/mysite/coins/views.py
+++ b/mysite/coins/views.py
@@ -14,6 +14,12 @@ def index(request):
 # After user clicks on a coin
 def coin_data(request):
     qid = request.GET.get("id")
-    data = get_coin(qid)
+    in_arabic = False
+    labels = ["Description", "Location of Creation", "Time Period", "Inception", "Made From Material", "Die Axis", "Diameter", "Mass", "Inventory Number", "Wikidata Q identifier"]
+    if "in_arabic" in request.GET and request.GET.get("in_arabic") == "true":
+        in_arabic = True
+        # NOTE: DIE AXIS WAS THE ONLY LABEL WITHOUT A TRANSLATION ON WIKIDATA, SO THIS TEMPORARILY USES A GOOGLE TRANSLATION
+        labels = ["الوصف", "موقع التجميع النهائي", "الفترة الزمنية", "البداية", "المواد المستخدمة", "محور يموت", "القطر", "الكتلة", "مُعرِّف الجَرد", "معرف ويكي بيانات"]
+    data = get_coin(qid, in_arabic)
     data.append(qid)
-    return render(request, "coins/coin_data.html", {"data": data})
+    return render(request, "coins/coin_data.html", {"data": data, "labels":labels, "in_arabic":(True if in_arabic else False)})


### PR DESCRIPTION
The Arabic translations were pulled from Wikidata as instructed by Professor Chen. 

This is just the start of tackling this task. Note that there is still more to do with this:
- The navigation bar, title, and Toggle Interactive Lighting labels should be in Arabic to be more accessible
- The Die Axis label didn't have a Wikidata translation so a temporary google translate label was used
- I don't know if the splitting of the item label (that works in English) in Arabic is always what we want
- More Arabic translations for the main page
- What should be done for the values that don't have a translation from Wikidata?

![screencapture-raspberrypi-bee-puffin-ts-net-8080-proxy-8000-coin-data-2023-04-23-00_38_51](https://user-images.githubusercontent.com/49346497/233820177-a170a1b6-24c7-48c6-9048-3a7266837526.png)
